### PR TITLE
We do not actually need github-branch-source here; git suffices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.14</version>
-    <relativePath />
+    <version>2.19</version>
+    <relativePath/>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>pipeline-github-lib</artifactId>
-  <version>1.0-beta-2-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Pipeline: GitHub Groovy Libraries</name>
@@ -44,7 +44,7 @@ THE SOFTWARE.
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -62,50 +62,27 @@ THE SOFTWARE.
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>cloudbees-folder</artifactId>
-      <version>5.15</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>scm-api</artifactId>
-      <version>2.0.1-beta-1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>branch-api</artifactId>
-      <version>2.0.0-beta-1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>github-branch-source</artifactId>
-      <version>2.0.0-beta-1</version>
+      <artifactId>git</artifactId>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.3</version>
+      <version>2.5</version>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Should fix linkage errors in `workflow-aggregator` tests, among other things. @stephenc’s https://github.com/jenkinsci/workflow-aggregator-plugin/commit/a3ae6c166c5813f35557cc6a94ea1edd0c2eebe7 may have broken that.

@reviewbybees