### PR TITLE
Support enterprise github urls

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/github/library/GitHubLibraryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/github/library/GitHubLibraryResolver.java
@@ -47,7 +47,7 @@ import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
     @Override public Collection<LibraryConfiguration> forJob(Job<?,?> job, Map<String,String> libraryVersions) {
         List<LibraryConfiguration> libs = new ArrayList<>();
         for (Map.Entry<String,String> entry : libraryVersions.entrySet()) {
-            if (entry.getKey().matches("github[.]com/([^/]+)/([^/]+)")) {
+            if (entry.getKey().matches("github.([^/]+[.])?com/([^/]+)/([^/]+)")) {
                 String name = entry.getKey();
                 // Currently GitHubSCMSource offers no particular advantage here over GitSCMSource.
                 LibraryConfiguration lib = new LibraryConfiguration(name, new SCMSourceRetriever(new GitSCMSource(null, "https://" + name + ".git", "", "*", "", true)));


### PR DESCRIPTION
It would be nice if we can enhance this to support enterprise github urls too. 

Especially we have an instance **github.domain.com**. 

Not sure if we need to expand this to support more options? Any suggestions. 

Really appreciate your time. Thanks for the good work. 