### PR TITLE
Use GitHub as a source of plugin documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,3 @@
 
 A Jenkins Plugin that allows pipeline Groovy libraries to be loaded on the fly from GitHub.
 
-Additional resources:
-
-* https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+GitHub+Library+Plugin[Wiki page]

--- a/README.adoc
+++ b/README.adoc
@@ -7,5 +7,4 @@ A Jenkins Plugin that allows pipeline Groovy libraries to be loaded on the fly f
 
 ## Changelog
 
-See link:./CHANGES.md[CHANGES.md].
-
+See link:./CHANGES.adoc[changelog].

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,11 @@
 == Pipeline: GitHub Groovy Libraries
 
+image:https://img.shields.io/jenkins/plugin/v/pipeline-github-lib.svg[link="https://plugins.jenkins.io/pipeline-github-lib"]
+image:https://img.shields.io/jenkins/plugin/i/pipeline-github-lib.svg[link="https://plugins.jenkins.io/pipeline-github-lib"]
+
 A Jenkins Plugin that allows pipeline Groovy libraries to be loaded on the fly from GitHub.
+
+## Changelog
+
+See link:./CHANGES.md[CHANGES.md].
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <name>Pipeline: GitHub Groovy Libraries</name>
   <description>Allows Pipeline Groovy libraries to be loaded on the fly from GitHub.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+GitHub+Library+Plugin</url>
+  <url>https://github.com/jenkinsci/pipeline-github-lib-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
There is no Wiki content for this plugin, so I think we could just update the README stub and use it as a landing page